### PR TITLE
More permissive version string on the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Per usual, install Commander through Composer.
 
 ```js
 "require": {
-    "laracasts/commander": "1.1.*"
+    "laracasts/commander": "~1.0"
 }
 ```
 


### PR DESCRIPTION
This means we don't have to remember to update this on every release. The user can just increment the `0` to any minimum minor version they would like.
