### PR TITLE
Adding composer branch alias for master branch.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,4 +18,9 @@
         }
     },
     "minimum-stability": "stable"
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.2.x-dev"
+        }
+    }
 }


### PR DESCRIPTION
It is much preferred to use symantec version, and branch aliases help a lot.
