### PR TITLE
Add $ to adhere to phpdoc standards

### DIFF
--- a/src/Laracasts/Commander/Console/stubs/command.stub
+++ b/src/Laracasts/Commander/Console/stubs/command.stub
@@ -11,7 +11,7 @@ class {{ name }} {
     {{/ properties}}
     /**
      {{# properties }}
-     * @param string {{ . }}
+     * @param string ${{ . }}
      {{/ properties }}
      */
     public function __construct({{ arguments }})


### PR DESCRIPTION
The variable name in the `@param` tag of doc blocks the should be prefixed with `$`.
