### PR TITLE
Change execute method from public to protected

### DIFF
--- a/src/Laracasts/Commander/CommanderTrait.php
+++ b/src/Laracasts/Commander/CommanderTrait.php
@@ -14,7 +14,7 @@ trait CommanderTrait {
      * @param  array $decorators
      * @return mixed
      */
-    public function execute($command, array $input = null, $decorators = [])
+    protected function execute($command, array $input = null, $decorators = [])
     {
         $input = $input ?: Input::all();
 


### PR DESCRIPTION
The execute method in the CommanderTrait should be protected as I can't see a need for the method to be publicly accessible.

I am not 100% sure on this so I could be wrong.
