### PR TITLE
[Fix] The bindShare resolution accepts only Closures

### DIFF
--- a/src/Laracasts/Commander/CommanderServiceProvider.php
+++ b/src/Laracasts/Commander/CommanderServiceProvider.php
@@ -49,7 +49,10 @@ class CommanderServiceProvider extends ServiceProvider {
      */
     protected function registerCommandBus()
     {
-        $this->app->bindShared('Laracasts\Commander\CommandBus', 'Laracasts\Commander\DefaultCommandBus');
+        $this->app->bindShared('Laracasts\Commander\CommandBus', function($app)
+        {
+            return $app->make('Laracasts\Commander\DefaultCommandBus');
+        });
     }
 
     /**


### PR DESCRIPTION
Hey, Jeffrey, I faced this issue: When I added the Service Provider to my providers list, it just fails saying that the bindShared accepts only a Closure as second parameter and this fixes it.
