### PR TITLE
Remove now unused toValidator method

### DIFF
--- a/src/Laracasts/Commander/BasicCommandTranslator.php
+++ b/src/Laracasts/Commander/BasicCommandTranslator.php
@@ -24,17 +24,4 @@ class BasicCommandTranslator implements CommandTranslator {
         return $handler;
     }
 
-    /**
-     * Translate a command to its validator counterpart
-     *
-     * @param $command
-     * @return mixed
-     */
-    public function toValidator($command)
-    {
-        $commandClass = get_class($command);
-
-        return substr_replace($commandClass, 'Validator', strrpos($commandClass, 'Command'));
-    }
-
 } 

--- a/src/Laracasts/Commander/CommandTranslator.php
+++ b/src/Laracasts/Commander/CommandTranslator.php
@@ -11,12 +11,4 @@ interface CommandTranslator {
      */
     public function toCommandHandler($command);
 
-    /**
-     * Translate a command to its validator counterpart.
-     *
-     * @param $command
-     * @return mixed
-     */
-    public function toValidator($command);
-
 }


### PR DESCRIPTION
Validation in Commander was ripped out due to Validation now being standardized in L5. Seemingly making the toValidator method now obsolete.
