### PR TITLE
Add mapping of camel case to snake case.

### DIFF
--- a/src/Laracasts/Commander/CommanderTrait.php
+++ b/src/Laracasts/Commander/CommanderTrait.php
@@ -2,7 +2,8 @@
 
 use ReflectionClass;
 use InvalidArgumentException;
-use Input, App, Str;
+use Input, App;
+use Illuminate\Support\Str;
 
 trait CommanderTrait {
 

--- a/src/Laracasts/Commander/CommanderTrait.php
+++ b/src/Laracasts/Commander/CommanderTrait.php
@@ -2,7 +2,7 @@
 
 use ReflectionClass;
 use InvalidArgumentException;
-use Input, App;
+use Input, App, Str;
 
 trait CommanderTrait {
 
@@ -65,6 +65,10 @@ trait CommanderTrait {
             if (array_key_exists($name, $input))
             {
                 $dependencies[] = $input[$name];
+            }
+            elseif (array_key_exists(Str::snake($name), $input))
+            {
+                $dependencies[] = $input[Str::snake($name)];
             }
             elseif ($parameter->isDefaultValueAvailable())
             {


### PR DESCRIPTION
In case of naming fields in HTML, we use a snake case, but in php we prefer camel case. It would be nice if Commander will try to do it without our help and will check if field in the Command is in camel case and in request is in snake case.
