### PR TITLE
Switch to bind to prevent decorator sharing

### DIFF
--- a/src/Laracasts/Commander/CommanderServiceProvider.php
+++ b/src/Laracasts/Commander/CommanderServiceProvider.php
@@ -49,7 +49,7 @@ class CommanderServiceProvider extends ServiceProvider {
      */
     protected function registerCommandBus()
     {
-        $this->app->bindShared('Laracasts\Commander\CommandBus', function($app)
+        $this->app->bind('Laracasts\Commander\CommandBus', function($app)
         {
             return $app->make('Laracasts\Commander\DefaultCommandBus');
         });


### PR DESCRIPTION
Sometimes you may need to execute multiple commands at the same time, it will accidentally share same decorators which is not intended that they should be, because the decorators array is store in the shared command bus.

e.g.
$this->execute(PostJobListingCommand::class, $data, JobSanitizer);
$this->execute(ClearCacheCommand::class);

The second execute will take the JobSanitizer docorator which is not intended.
