### PR TITLE
If we've passed a command instance, just use that.

### DIFF
--- a/src/Laracasts/Commander/CommanderTrait.php
+++ b/src/Laracasts/Commander/CommanderTrait.php
@@ -54,6 +54,11 @@ trait CommanderTrait {
      */
     protected function mapInputToCommand($command, array $input)
     {
+        if (is_object($command)) {
+
+            return $command;
+        }
+        
         $dependencies = [];
 
         $class = new ReflectionClass($command);


### PR DESCRIPTION
This is much cleaner if we don't necessarily care about mapping input.

We use this pattern all over the place - not just in controllers and this really shines in those cases.

Eager to hear your feedback - cheers!
